### PR TITLE
77 Transaction Recall in Abstraction Incorrect on First Search Key Recall

### DIFF
--- a/Jube.Data/Cache/Redis/CachePayloadRepository.cs
+++ b/Jube.Data/Cache/Redis/CachePayloadRepository.cs
@@ -135,7 +135,7 @@ public class CachePayloadRepository(
                          $"Payload:{tenantRegistryId}:{entityAnalysisModelGuid:N}",
                          (from sortedSetEntry in sortedSetEntries
                              where sortedSetEntry.Element.ToString() !=
-                                   entityInconsistentAnalysisModelInstanceEntryGuid.ToString()
+                                   entityInconsistentAnalysisModelInstanceEntryGuid.ToString("N")
                              select sortedSetEntry.Element).ToArray()))
                 try
                 {


### PR DESCRIPTION
This issue was introduced in #6.

The GetExcludeCurrent method in the CachePayloadRepository was not filtering out the current transaction in flight despite the logic being in place. The issue was introduced during refactoring of Redis storage as GUID values are stored with the hyphens stripped, however, this was neglected to be included in this methods evaluation. It follows that when the string comparison took place, Redis presented GUID values without hyphens, and the transaction in process contained hyphens, and this did not return true on the test. Changed the ToString format function for the evaluation to strip the hyphens (i.e, ToString("N")).